### PR TITLE
Fix bug in comparing BigInt values

### DIFF
--- a/src/section-validators/base.ts
+++ b/src/section-validators/base.ts
@@ -1,4 +1,4 @@
-import { assert, AssertionError } from "chai";
+import { AssertionError } from "chai";
 import chalk from "chalk";
 import { Contract, JsonRpcProvider, Result } from "ethers";
 
@@ -132,10 +132,7 @@ function _stringify(value: unknown) {
 }
 
 function _assertEqual(actual: unknown, expected: ViewResult, errorMessage?: string) {
-  if (typeof actual === "bigint") {
-    assert(typeof expected === "string" || typeof expected === "bigint");
-    _equalOrThrow(actual, BigInt(expected), errorMessage);
-  } else if (Array.isArray(expected)) {
+  if (Array.isArray(expected)) {
     _equalOrThrow(
       (actual as unknown[]).length,
       expected.length,
@@ -177,8 +174,19 @@ function _assertEqualStruct(expected: null | ArbitraryObject, actual: Result) {
   }
 }
 
+function toBigIntIfPossible(value: unknown): bigint | unknown {
+  if (typeof value === "string" || typeof value === "number") {
+    try {
+      return BigInt(value);
+    } catch {
+      return value;
+    }
+  }
+  return value;
+}
+
 function _equalOrThrow(actual: unknown, expected: unknown, errorMessage?: string) {
-  if (actual !== expected) {
+  if (toBigIntIfPossible(actual) !== toBigIntIfPossible(expected)) {
     if (!errorMessage) {
       errorMessage = `Expected "${_stringify(expected)}" to equal actual "${_stringify(actual)}"`;
     }


### PR DESCRIPTION
AS IS:
![image](https://github.com/user-attachments/assets/d3d870e4-fb3e-4857-afa0-072c2ae33842)
TO BE:
![image](https://github.com/user-attachments/assets/698ed74b-b9b8-40da-8418-e3a8dd7c17f0)

DIFF:
![image](https://github.com/user-attachments/assets/39150f47-9a2d-43b2-8052-f6f714717f41)

The line that performs the check is [here](https://github.com/Alexvozhak/state-mate-typed/blob/5a15331c302592a6ddf21830532a6b65ba38a6cd/configs/hoodi/lidov3-testnet.yaml#L1985)